### PR TITLE
Use 'global' instead of 'window' for web worker compatibility

### DIFF
--- a/ampersand-version.js
+++ b/ampersand-version.js
@@ -13,9 +13,9 @@ module.exports = function (file) {
     var version = pack.version;
 
     var codeString = ';' + [
-        'window.ampersand = window.ampersand || {};',
-        'window.ampersand["' + name + '"] = window.ampersand["' + name + '"] || [];',
-        'window.ampersand["' + name + '"].push("' + version + '");'
+        'global.ampersand = global.ampersand || {};',
+        'global.ampersand["' + name + '"] = global.ampersand["' + name + '"] || [];',
+        'global.ampersand["' + name + '"].push("' + version + '");'
     ].join('');
 
     return through(function (buf, enc, next) {


### PR DESCRIPTION
Fixes #2 
